### PR TITLE
PR to allow for custom branch name to be used

### DIFF
--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -17,6 +17,9 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 	def get_template_vars(self):
 		return dict(url=self._settings.get(["url"]), path=self._settings.get(["path"]))
 
+	def get_template_vars(self):
+		return dict(url=self._settings.get(["mybranch"]), path=self._settings.get(["mybranch"]))
+
 	def get_template_configs(self):
 		return [dict(type="settings", custom_bindings=False)]
 

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -68,7 +68,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
 				self._logger.info("-- git {} origin {mybranch} ---------------------------------------------------".format(verb))
-				output =  call(["git", verb, "origin", "{mybranch} ], cwd=gitfilesFolder)
+				output =  call(["git", verb, "origin", "{mybranch}" ], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))
 			except OSError as e:

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -68,7 +68,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
 				self._logger.info("-- git {} origin ", mybranch, " ---------------------------------------------------".format(verb))
-				output =  call(["git", verb, "origin", " ", mybranch ], cwd=gitfilesFolder)
+				output =  call(["git", verb, "origin", mybranch ], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))
 			except OSError as e:

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -12,14 +12,14 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
                      octoprint.plugin.TemplatePlugin):
 
 	def get_settings_defaults(self):
-		return dict(url="https://github.com/YourUserID/YourRepository.git", path="gitfiles")
+		return dict(url="https://github.com/YourUserID/YourRepository.git", path="gitfiles", mybranch="branchname")
 
 	def get_template_vars(self):
-		return dict(url=self._settings.get(["url"]), path=self._settings.get(["path"]))
-
+		return dict(url=self._settings.get(["url"]), path=self._settings.get(["path"]), path=self._settings.get(["mybranch"]))
+/*
 	def get_template_vars(self):
 		return dict(url=self._settings.get(["mybranch"]), path=self._settings.get(["mybranch"]))
-
+*/
 	def get_template_configs(self):
 		return [dict(type="settings", custom_bindings=False)]
 

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -67,8 +67,8 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
-				self._logger.info("-- git {} origin {mybranch} ---------------------------------------------------".format(verb))
-				output =  call(["git", verb, "origin", "{mybranch}" ], cwd=gitfilesFolder)
+				self._logger.info("-- git {} origin ", mybranch, " ---------------------------------------------------".format(verb))
+				output =  call(["git", verb, "origin", " ", mybranch ], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))
 			except OSError as e:

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -67,7 +67,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
-				self._logger.info("-- git {} origin" + mybranch + " ---------------------------------------------------".format(verb))
+				self._logger.info("-- git {} origin " + mybranch + " ---------------------------------------------------".format(verb))
 				output =  call(["git", verb, "origin", mybranch], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -42,6 +42,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 			uploads = self._settings.global_get_basefolder("uploads")
 			path =    self._settings.get(["path"])
 			url =     self._settings.get(["url"])
+			mybranch =  self._settings.get(["mybranch"])
 			verb =    "{arg1}".format(**data)
 			
 			if path == "" or path == "uploads":
@@ -63,8 +64,8 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
-				self._logger.info("-- git {} origin master ---------------------------------------------------".format(verb))
-				output =  call(["git", verb, "origin", "master"], cwd=gitfilesFolder)
+				self._logger.info("-- git {} origin" + mybranch + " ---------------------------------------------------".format(verb))
+				output =  call(["git", verb, "origin", mybranch], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))
 			except OSError as e:
@@ -89,7 +90,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 			self._logger.info("`git init` failed")
 			return
 		try:
-			self._logger.info("Setting up the remote origin for master...")
+			self._logger.info("Setting up the remote origin for " + mybranch + "...")
 			output =  call(["git", "remote", "add", "origin", url], cwd=gitfilesFolder)
 			self._logger.info(output)
 		except OSError as e:

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -15,11 +15,8 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 		return dict(url="https://github.com/YourUserID/YourRepository.git", path="gitfiles", mybranch="branchname")
 
 	def get_template_vars(self):
-		return dict(url=self._settings.get(["url"]), path=self._settings.get(["path"]), path=self._settings.get(["mybranch"]))
-/*
-	def get_template_vars(self):
-		return dict(url=self._settings.get(["mybranch"]), path=self._settings.get(["mybranch"]))
-*/
+		return dict(url=self._settings.get(["url"]), path=self._settings.get(["path"]), mybranch=self._settings.get(["mybranch"]))
+
 	def get_template_configs(self):
 		return [dict(type="settings", custom_bindings=False)]
 

--- a/octoprint_gitfiles/__init__.py
+++ b/octoprint_gitfiles/__init__.py
@@ -67,8 +67,8 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 
 			# This one runs regardless of whether or not it's been previously initialized
 			try:
-				self._logger.info("-- git {} origin " + mybranch + " ---------------------------------------------------".format(verb))
-				output =  call(["git", verb, "origin", mybranch], cwd=gitfilesFolder)
+				self._logger.info("-- git {} origin {mybranch} ---------------------------------------------------".format(verb))
+				output =  call(["git", verb, "origin", "{mybranch} ], cwd=gitfilesFolder)
 				self._logger.info("git returned: " + str(output))
 				self._logger.info("-- (end of git {}) --------------------------------------------------------".format(verb))
 			except OSError as e:
@@ -93,7 +93,7 @@ class GitfilesPlugin(octoprint.plugin.SettingsPlugin,
 			self._logger.info("`git init` failed")
 			return
 		try:
-			self._logger.info("Setting up the remote origin for " + mybranch + "...")
+			self._logger.info("Setting up the remote origin for {mybranch} ...")
 			output =  call(["git", "remote", "add", "origin", url], cwd=gitfilesFolder)
 			self._logger.info(output)
 		except OSError as e:

--- a/octoprint_gitfiles/templates/gitfiles_settings.jinja2
+++ b/octoprint_gitfiles/templates/gitfiles_settings.jinja2
@@ -21,6 +21,12 @@
                 <input type="text" class="input-block-level" data-bind="value: settings.plugins.gitfiles.path">
             </div>
         </div>
+        <div class="control-group">
+            <label class="control-label">{{ _('Branch:') }}</label>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.gitfiles.mybranch">
+            </div>
+        </div>
     </form>
     <table><tr><td valign="top"><h3>{{ _('General workflow') }}</h3>
         <ol>

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.5a"
+plugin_version = "1.1.6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.7"
+plugin_version = "1.1.7.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.7.1"
+plugin_version = "1.1.7.2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@
 ### Do not forget to adjust the following variables to your own plugin.
 
 # The plugin's identifier, has to be unique
-plugin_identifier = "gitfiles-m1xzg"
+plugin_identifier = "gitfiles"
 
 # The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique
-plugin_package = "octoprint_gitfiles-m1xzg"
+plugin_package = "octoprint_gitfiles"
 
 # The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
 # plugin module
-plugin_name = "GitFiles-m1xzg"
+plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 plugin_version = "1.1.5"

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@
 ### Do not forget to adjust the following variables to your own plugin.
 
 # The plugin's identifier, has to be unique
-plugin_identifier = "gitfiles"
+plugin_identifier = "gitfiles-m1xzg"
 
 # The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique
-plugin_package = "octoprint_gitfiles"
+plugin_package = "octoprint_gitfiles-m1xzg"
 
 # The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
 # plugin module
-plugin_name = "GitFiles"
+plugin_name = "GitFiles-m1xzg"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 plugin_version = "1.1.5"
@@ -27,7 +27,7 @@ plugin_author = "OutsourcedGuru"
 plugin_author_email = "support@outsourced.guru"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/OutsourcedGuru/OctoPrint-GitFiles"
+plugin_url = "https://github.com/M1XZG/OctoPrint-GitFiles"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.6"
+plugin_version = "1.1.7"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.7.2"
+plugin_version = "1.1.7.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.7.3"
+plugin_version = "1.1.5.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -27,7 +27,7 @@ plugin_author = "OutsourcedGuru"
 plugin_author_email = "support@outsourced.guru"
 
 # The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
-plugin_url = "https://github.com/M1XZG/OctoPrint-GitFiles"
+plugin_url = "https://github.com/OutsourcedGuru/OctoPrint-GitFiles"
 
 # The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_gitfiles"
 plugin_name = "GitFiles"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.1.5"
+plugin_version = "1.1.5a"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I've removed the hard coded `master` repository and the plugin will now allow the user to enter their own branchname. One reason for this is that `master` is no longer the default branch of new repos, so anyone installing the plugin after Oct 2020 they will struggle due to the hardcoded branch name.

The other scenario this will be useful is for those with multiple printers but would like to use a common repo to store code in but the gcode has been sliced for those different printers, ie: my K8800 might use a branch name of k8800 but my prusa might have another name.

These changes are all fully functional and I've been testing them with 100% success.  The new configuration page looks like:

![image](https://user-images.githubusercontent.com/22931360/99236971-c3c3fb00-27ef-11eb-8938-68b9bb1d1ff2.png)

I've incremented the version to 1.1.5.1, but that convention is entirely for you to adjust. I was using that for my testing.
